### PR TITLE
Update TFM to .NET 6 and update NuGet Packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET
 
 on:
   push:
@@ -12,32 +12,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 3.1.101
-    - name: Install dependencies
+        dotnet-version: '6.0.x'
+
+    - name: Install Dependencies
       run: dotnet restore
-    - name: update event key
+
+    - name: Update Event Key
       uses: deef0000dragon1/json-edit-action/@v1
       env:
         KEY: EventsDiscordWebHookURL
         VALUE: ${{ secrets.DISCORDEVENT }}
         FILE: keys.json
-    - name: update channel key
+
+    - name: Update Channel Key
       uses: deef0000dragon1/json-edit-action/@v1
       env:
         KEY: ChannelDiscordWebHookURL
         VALUE: ${{ secrets.DISCORDEVENT }}
         FILE: keys.json
+
     - name: Build
       run: dotnet build --no-restore --verbosity normal
+
     - name: Test
       run: dotnet test --configuration Release --no-restore
-    - name: dotnet publish
-      run: dotnet publish ArchaicQuestII.API/ArchaicQuestII.API.csproj -c Release -o deploy -r ubuntu.19.04-x64
-    - name: Copy via ssh
+
+    - name: DotNet Publish
+      run: dotnet publish ArchaicQuestII.API/ArchaicQuestII.API.csproj -c Release -o deploy --self-contained true -r linux-x64
+
+    - name: Copy via SSH
       uses: garygrossgarten/github-action-scp@v0.5.3
       with:
         local: deploy
@@ -45,11 +53,11 @@ jobs:
         host: ${{ secrets.SSH_HOST }}
         username: ${{ secrets.SSH_USER }}
         privateKey: ${{ secrets.SSH_KEY }}
-    - name: Run SSH command
+
+    - name: Run SSH Command
       uses: garygrossgarten/github-action-ssh@v0.3.0
       with:
         command: sudo systemctl restart archaicquest_api.service
         host: ${{ secrets.SSH_HOST }}
         username: ${{ secrets.SSH_USER }}
         privateKey: ${{ secrets.SSH_KEY }}
-    

--- a/ArchaicQuestII.API/ArchaicQuestII.API.csproj
+++ b/ArchaicQuestII.API/ArchaicQuestII.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp31</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
@@ -34,12 +34,11 @@
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
-
-        <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.4" />
+        <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ArchaicQuestII.DataAccess.Tests/ArchaicQuestII.DataAccess.Tests.csproj
+++ b/ArchaicQuestII.DataAccess.Tests/ArchaicQuestII.DataAccess.Tests.csproj
@@ -1,17 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp31</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-        <PackageReference Include="Moq" Version="4.12.0" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Moq" Version="4.17.2" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/ArchaicQuestII.DataAccess/ArchaicQuestII.DataAccess.csproj
+++ b/ArchaicQuestII.DataAccess/ArchaicQuestII.DataAccess.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp31</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LiteDB" Version="5.0.8" />
+        <PackageReference Include="LiteDB" Version="5.0.11" />
     </ItemGroup>
 
 </Project>

--- a/ArchaicQuestII.GameLogic.Tests/ArchaicQuestII.GameLogic.Tests.csproj
+++ b/ArchaicQuestII.GameLogic.Tests/ArchaicQuestII.GameLogic.Tests.csproj
@@ -1,24 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp31</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-        <PackageReference Include="Moq" Version="4.14.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Moq" Version="4.17.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
-
 
     <ItemGroup>
         <ProjectReference Include="..\ArchaicQuestII.GameLogic\ArchaicQuestII.GameLogic.csproj" />
     </ItemGroup>
-
 
     <ItemGroup>
       <Folder Include="Character\NewFolder\" />

--- a/ArchaicQuestII.GameLogic/ArchaicQuestII.GameLogic.csproj
+++ b/ArchaicQuestII.GameLogic/ArchaicQuestII.GameLogic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp31</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
           <DebugType>portable</DebugType>
     </PropertyGroup>
@@ -19,38 +19,29 @@
       <Compile Remove="Core\Time - Copy.cs" />
     </ItemGroup>
 
- 
     <ItemGroup>
       <None Remove="Core\Keys.json" />
     </ItemGroup>
 
- 
     <ItemGroup>
-        <PackageReference Include="Markdig" Version="0.26.0" />
+        <PackageReference Include="Markdig" Version="0.30.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
         <PackageReference Include="MoonSharp" Version="2.0.0" />
     </ItemGroup>
 
-
-
     <ItemGroup>
         <ProjectReference Include="..\ArchaicQuestII.DataAccess\ArchaicQuestII.DataAccess.csproj" />
     </ItemGroup>
-
-
 
     <ItemGroup>
       <Folder Include="Commands\Character\" />
       <Folder Include="Skill\Type\" />
     </ItemGroup>
 
-
-
     <ItemGroup>
       <Resource Include="Core\Keys.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Resource>
     </ItemGroup>
-
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Some of the above can be edited in the admin tool, the rest if required to be ch
 The last important step that isn't seeded yet is the very first room! For now before connecting to the game you will need to fire up the web admin tool and create an area and then create a room in said area. Then the web client will be able to connect correctly. 
 
 ### Running the project
-Use `dotnet run -p ArchaicQuestII.API/ArchaicQuestII.API.csproj`.
+Use `dotnet run --project ArchaicQuestII.API/ArchaicQuestII.API.csproj`.
 
 If on unix you can use the make file in the project to run using `make run`. 
 


### PR DESCRIPTION
Updated target framework to .NET 6 and updated referenced NuGet packages to latest.

This PR does not attempt to migrate the API project to the new [minimal hosting model](https://docs.microsoft.com/en-us/aspnet/core/migration/50-to-60#use-startup-with-the-new-minimal-hosting-model) introduced in .NET 6.