### PR TITLE
Create Separate Actions Workflow for Pull Requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Install Dependencies
+      run: dotnet restore
+
+    - name: Build Project
+      run: dotnet build --no-restore --verbosity normal
+
+    - name: Run Tests
+      run: dotnet test --configuration Release --no-restore
+
+    - name: Publish Binaries
+      run: dotnet publish ArchaicQuestII.API/ArchaicQuestII.API.csproj -c Release -o deploy --self-contained true -r linux-x64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
-name: .NET
+name: deploy
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 jobs:
@@ -14,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Setup .NET
+    - name: Setup DotNet
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '6.0.x'
@@ -36,16 +34,16 @@ jobs:
         VALUE: ${{ secrets.DISCORDEVENT }}
         FILE: keys.json
 
-    - name: Build
+    - name: Build Project
       run: dotnet build --no-restore --verbosity normal
 
-    - name: Test
+    - name: Run Tests
       run: dotnet test --configuration Release --no-restore
 
-    - name: DotNet Publish
+    - name: Publish Binaries
       run: dotnet publish ArchaicQuestII.API/ArchaicQuestII.API.csproj -c Release -o deploy --self-contained true -r linux-x64
 
-    - name: Copy via SSH
+    - name: Deploy Binaries
       uses: garygrossgarten/github-action-scp@v0.5.3
       with:
         local: deploy
@@ -54,7 +52,7 @@ jobs:
         username: ${{ secrets.SSH_USER }}
         privateKey: ${{ secrets.SSH_KEY }}
 
-    - name: Run SSH Command
+    - name: Restart Service
       uses: garygrossgarten/github-action-ssh@v0.3.0
       with:
         command: sudo systemctl restart archaicquest_api.service


### PR DESCRIPTION
Create two separate workflows, one to validate Pull Requests and another to perform deployments.

`build` is run on Pull Requests targeting the default branch.
`deploy` is run on commits to the default branch.